### PR TITLE
Updating library to .netstandard2.0

### DIFF
--- a/Sources/CSharpIDW.Test/CSharpIDW.Test.csproj
+++ b/Sources/CSharpIDW.Test/CSharpIDW.Test.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Sources/CSharpIDW/CSharpIDW.csproj
+++ b/Sources/CSharpIDW/CSharpIDW.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR changes the library type to .netstandard2.0 for maximum compatibility (KdTree, the only dependency, has this as well), as .netstandard2.0 is the most compatible .net library type (compatible with .net framework, .net core, .net5, .net6 etc)

Also updated the unit test package version.